### PR TITLE
Fix na criação da descrição de eventos

### DIFF
--- a/app/repositories/event.py
+++ b/app/repositories/event.py
@@ -40,7 +40,7 @@ class EventRepository:
                 id=str(uuid4()),
                 chart_id=event.chart_id,
                 name=event.name,
-                description=event.name,
+                description=event.description,
                 date=event.date,
                 color=event.color
             ).returning(Event)


### PR DESCRIPTION
A descrição não recebe mais o mesmo valor do nome na criação de eventos